### PR TITLE
0.1.3-pre-alpha Fri Dec 18 20:11:31 UTC 2020

### DIFF
--- a/READY.FOR.RELEASE
+++ b/READY.FOR.RELEASE
@@ -1,0 +1,1 @@
+0.1.3-pre-alpha Fri Dec 18 20:11:31 UTC 2020


### PR DESCRIPTION
See recent commits - too difficult to merge during a release
(README.md had conflicts - wasn't expecting the headache).

This Release - operates the system similarly to as-used past several months.

Need to manually init the USART (USART6) to talk to the Lumex display.

test6 ok
eflogo ok
linit ok
5 blinks ok

That'll more than do it - small refinement got misplaced (no blue letters).

Look at the definition of 'test6' to find initialization required to use the Lumex display on USART6.